### PR TITLE
Improve `delete-work --all` and a few more minor changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+*~
+.#*
+*.bak
+.*.swp
+.*.swo
+*.o
+*.hi
+*~
+*#
+.DS_Store
+.stack-work
+TAGS
+tags

--- a/src/Directories.hs
+++ b/src/Directories.hs
@@ -25,7 +25,7 @@ switchToSystemDirUnder :: FilePath -> IO ()
 switchToSystemDirUnder dir = do
   ifM (doesDirectoryExist dir)
     (setCurrentDirectory dir)
-    (error' $ dir ++ "not found")
+    (error' $ dir ++ " not found")
   systems <- listDirectory "."
   -- FIXME be more precise/check "system" dirs
   -- eg 64bit intel Linux: x86_64-linux-tinfo6

--- a/src/Remove.hs
+++ b/src/Remove.hs
@@ -11,7 +11,7 @@ import qualified System.Directory as D
 doRemoveDirectory :: Bool -> FilePath -> IO ()
 doRemoveDirectory dryrun dir =
   unless dryrun $
-    D.removeDirectoryRecursive dir
+  D.removeDirectoryRecursive dir
 
 removeFile :: Bool -> FilePath -> IO ()
 removeFile dryrun file =

--- a/src/Remove.hs
+++ b/src/Remove.hs
@@ -10,8 +10,9 @@ import qualified System.Directory as D
 
 doRemoveDirectory :: Bool -> FilePath -> IO ()
 doRemoveDirectory dryrun dir =
-  unless dryrun $
-  D.removeDirectoryRecursive dir
+  unless dryrun $ do
+    putStrLn $ "Removing " ++ show dir
+    D.removeDirectoryRecursive dir
 
 removeFile :: Bool -> FilePath -> IO ()
 removeFile dryrun file =

--- a/src/Remove.hs
+++ b/src/Remove.hs
@@ -10,8 +10,7 @@ import qualified System.Directory as D
 
 doRemoveDirectory :: Bool -> FilePath -> IO ()
 doRemoveDirectory dryrun dir =
-  unless dryrun $ do
-    putStrLn $ "Removing " ++ show dir
+  unless dryrun $
     D.removeDirectoryRecursive dir
 
 removeFile :: Bool -> FilePath -> IO ()

--- a/src/Snapshots.hs
+++ b/src/Snapshots.hs
@@ -170,15 +170,9 @@ removeStackWorks dryrun allrecurse = do
     else doesDirectoryExist ".stack-work"
   if recurse then do
     -- ignore find errors (e.g. access rights)
-    workdirs <- removeSubdirectories . lines <$> cmdIgnoreErr "find" [".", "-type", "d", "-name", ".stack-work"] []
+    workdirs <- sort . lines <$> cmdIgnoreErr "find" [".", "-type", "d", "-name", ".stack-work", "-prune"] []
     unless (null workdirs) $ do
       mapM_ putStrLn workdirs
       Remove.prompt dryrun "these dirs"
       mapM_ (Remove.doRemoveDirectory dryrun) workdirs
     else error' "run in a project dir (containing .stack-work/)\n or use --all to find and remove all .stack-work/ subdirectories"
-
-removeSubdirectories :: [FilePath] -> [FilePath]
-removeSubdirectories = reverse . foldl updateIfNoPrefix [] . sort
-  where
-    updateIfNoPrefix [] path = [path]
-    updateIfNoPrefix prefixes@(p:_) path = if p `isPrefixOf` path then prefixes else path : prefixes


### PR DESCRIPTION
Hi,

 I found that when using `delete-work --all` it would fail if there are sub-directories where you do not have access writes (because find exits with 1), and if there are `.stack-work` directories within upper-level `.stack-work`s.

While working on it I created a .gitignore, I hope it's ok that I've included it too.

I'm a haskell noob and so I hope this PR is not too presumptuous.