### PR TITLE
issue 14

### DIFF
--- a/src/GHC.hs
+++ b/src/GHC.hs
@@ -33,13 +33,16 @@ setStackProgramsDir msystem =
 getGhcInstallDirs :: Maybe Version -> Maybe String -> IO [FilePath]
 getGhcInstallDirs mghcver msystem = do
   setStackProgramsDir msystem
-  sortOn ghcInstallVersion <$> globDirs ("ghc-" ++ matchVersion)
+  dirs <- map dropTrailingSlash <$> globDirs ("ghc-" ++ matchVersion)
+  return $ sortOn ghcInstallVersion dirs
   where
+    -- 'globDirs' may return something like @["ghc-9.4.5/"]@, so, need to clean trailing slash.
+    dropTrailingSlash = dropWhileEnd (\ c -> c == '/' || c == '\\')
     matchVersion =
       case mghcver of
         Nothing -> "*"
         Just ver ->
-          "*-" ++ showVersion ver ++ if isMajorVersion ver then "*" else ""
+          showVersion ver ++ if isMajorVersion ver then "*" else ""
 
 ghcInstallVersion :: FilePath -> Version
 ghcInstallVersion =

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-18.18
+resolver: lts-20.26


### PR DESCRIPTION
- Bump stack.yaml to GHC 9.2.8 (newest with final LTS)
- Fix #14: bug in glob expression that lists specific installed ghc
